### PR TITLE
feat(class Buffer): adds distinguishing between disk files and sockets

### DIFF
--- a/inc/Buffer.hpp
+++ b/inc/Buffer.hpp
@@ -88,14 +88,30 @@ public:
   /// \returns -1 if buffer is full
   /// \returns amount of bytes filled into buffer otherwise
   /// throws exception on error
-  ssize_t fill(const int Fd, const size_t Bytes);
+  ssize_t fileToBuf(const int Fd, const size_t Bytes);
 
   /// \brief reads Bytes bytes from Buffer and sends them to Fd
   ///
   /// \returns -1 if buffer is empty
   /// \returns amount of bytes emptied into Fd otherwise
   /// throws exception on error
-  ssize_t empty(const int Fd, const size_t Bytes);
+  ssize_t bufToFile(const int Fd, const size_t Bytes);
+
+  /// \brief reads up to Bytes bytes from Socket into buffer in non-blocking
+  /// mode
+  ///
+  /// \returns -1 if buffer is full
+  /// \returns amount of bytes filled into buffer otherwise
+  /// throws exception on error
+  ssize_t socketToBuf(const int Socket, const size_t Bytes);
+
+  /// \brief reads Bytes bytes from Buffer and sends them to Socket in
+  /// non-blocking mode
+  ///
+  /// \returns -1 if buffer is empty
+  /// \returns amount of bytes emptied into Fd otherwise
+  /// throws exception on error
+  ssize_t bufToSocket(const int Socket, const size_t Bytes);
 
   /// \brief moves meaningful data to the front of the buffer.
   void format(void);
@@ -112,7 +128,7 @@ public:
   void deleteFront(const size_t Bytes);
 
 private:
-  char _buffer[BUFFER_SIZE];
   size_t _start;
   size_t _end;
+  char _buffer[BUFFER_SIZE];
 };

--- a/src/dsa/Buffer.cpp
+++ b/src/dsa/Buffer.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <errno.h>
 #include <stdexcept>
+#include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -66,7 +67,7 @@ size_t Buffer::getFree(void) const {
   return size - _end;
 }
 
-ssize_t Buffer::fill(const int Fd, const size_t Bytes) {
+ssize_t Buffer::fileToBuf(const int Fd, const size_t Bytes) {
   if (getUsed() == size)
     return -1;
   // the following the second part of the or condition could turn out to
@@ -86,12 +87,46 @@ ssize_t Buffer::fill(const int Fd, const size_t Bytes) {
   return rc;
 }
 
-ssize_t Buffer::empty(const int Fd, const size_t Bytes) {
+ssize_t Buffer::bufToFile(const int Fd, const size_t Bytes) {
   if (getUsed() == 0)
     return -1;
   const size_t amount = std::min(Bytes, getUsed());
   errno = 0;
   const ssize_t rc = write(Fd, _buffer + _start, amount);
+  if (rc < 0)
+    throw std::runtime_error(strerror(errno));
+  _start += (size_t)rc; // safe because rc >= 0 and rc <= getUsed()
+  if (_start == _end)
+    reset();
+  return rc;
+}
+
+ssize_t Buffer::socketToBuf(const int Socket, const size_t Bytes) {
+  if (getUsed() == size)
+    return -1;
+  // the following the second part of the or condition could turn out to
+  // be a problem in the following case:
+  // 1. getBlocked() is small
+  // 2. getUsed() is big
+  // It could be better to skip filling all together in this case.
+  // Probably shoud be handled somewhere else though
+  if (getUsed() == 0 || (getFree() == 0 && getBlocked() != 0))
+    format();
+  const size_t amount = std::min(Bytes, getFree());
+  errno = 0;
+  const ssize_t rc = recv(Socket, _buffer + _end, amount, 0);
+  if (rc < 0)
+    throw std::runtime_error(strerror(errno));
+  _end += (size_t)rc; // safe because rc >= 0 and rc <= getFree()
+  return rc;
+}
+
+ssize_t Buffer::bufToSocket(const int Socket, const size_t Bytes) {
+  if (getUsed() == 0)
+    return -1;
+  const size_t amount = std::min(Bytes, getUsed());
+  errno = 0;
+  const ssize_t rc = send(Socket, _buffer + _start, amount, MSG_DONTWAIT);
   if (rc < 0)
     throw std::runtime_error(strerror(errno));
   _start += (size_t)rc; // safe because rc >= 0 and rc <= getUsed()

--- a/src/response/ResponseProcess.cpp
+++ b/src/response/ResponseProcess.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <stdexcept>
 #include <string>
+#include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -80,7 +81,7 @@ static bool stringToSocket(const int Socket, std::string &Str,
   if (Str.empty())
     return true;
   const size_t amount = std::min(Bytes, Str.size());
-  const ssize_t rc = write(Socket, Str.c_str(), amount);
+  const ssize_t rc = send(Socket, Str.c_str(), amount, MSG_DONTWAIT);
   if (rc < 0) {
     logging::log3(logging::Error, __func__, ": ", strerror(errno));
     return false;
@@ -100,7 +101,7 @@ static bool fileToSocket(const int Socket, int &FileFd, Buffer &Buf,
     // edgecase = FileFd empties by exactly filling up Buf. Then empty FileFd
     // would be passed one more time; theory: does not matter as FileFd will
     // spill just 0 next iteration and no exception will be thrown
-    const ssize_t rc = Buf.fill(FileFd, Bytes);
+    const ssize_t rc = Buf.fileToBuf(FileFd, Bytes);
     if ((size_t)rc < Bytes && Buf.getFree() > 0) {
       if (close(FileFd) < 0)
         logging::log2(logging::Error, "close: ", strerror(errno));
@@ -110,7 +111,7 @@ static bool fileToSocket(const int Socket, int &FileFd, Buffer &Buf,
   const size_t used = Buf.getUsed();
   if (used == 0) // nothing read from FileFd and no residue from last time
     return true;
-  const ssize_t rc = Buf.empty(Socket, Bytes);
+  const ssize_t rc = Buf.bufToSocket(Socket, Bytes);
   if (FileFd == -1 && ((rc >= 0) && (size_t)rc == used))
     return true;
   return false;


### PR DESCRIPTION

renames the following functions:
`Buffer::fill()`         -> `Buffer::fileToBuf()`
`Buffer::empty()`  -> `Buffer::bufToFile()`

adds the following functions:
`Buffer::socketToBuf()`
`Buffer::bufToSocket()`

This hopefully will allow us to have better control when it comes to managing different sources of I/O and avoid blocking.

I am uncertain if calling `recv()` with `flags = 0` in `Buffer::socketToBuf()` is correct. I assume it depends on the general socket behavior which I have not yet fully understood