### PR TITLE
small update, streamlined logic

### DIFF
--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -70,13 +70,13 @@ class Server {
 	void process(void);
 	int  getSocketType(int Fd);
 	void serveAll(void);
-	bool shouldBeDeleted(int Fd);
-	void closeAndDelete(int Fd);
+	bool shouldBeDeleted(int Fd, int Type);
+	void closeAndDelete(int Fd, int Type);
 	void addConnectionToMap(int ListenerFd, const struct ClientAddr &Candidate);
 
 	// ServerHandlePoll.hpp
 	//bool reventsAreTerminal(int revents);
-	void handleCondition(struct pollfd &polled);
+	void handleCondition(struct pollfd &polled, int Type);
 	//void handleTerminalCondition(struct pollfd &polled);
 	//void handleServableCondition(struct pollfd &polled);
 	

--- a/src/server/ServerHandlePoll.cpp
+++ b/src/server/ServerHandlePoll.cpp
@@ -17,40 +17,28 @@
 
 /////////////////////////////////////////////////////////////////////////
 
-void Server::handleCondition(struct pollfd &polled) {
-  /*
-  if (reventsAreTerminal(polled.revents)) {
-    handleTerminalCondition(polled);
-  } else {
-    handleServableCondition(polled);
-  }
-  */
-  int type = getSocketType(polled.fd);
-  if (type == -1) {
-    logging::log3(logging::Error, "handleCondition(): fd ", polled.fd,
-                  "is not found in _clientMap or _fwdMap");
-    return;
-  }
+void Server::handleCondition(struct pollfd &polled, int Type) {
+  
   if (polled.revents & POLLNVAL) {
-    handlePollnval(polled.fd, type);
+    handlePollnval(polled.fd, Type);
     return;
   }
   if (polled.revents & POLLERR) {
-    handlePollerr(polled.fd, type);
+    handlePollerr(polled.fd, Type);
     return;
   }
   if (polled.revents & POLLHUP) {
-    handlePollhup(polled.fd, type);
+    handlePollhup(polled.fd, Type);
     return;
   }
   if ((polled.revents & POLLIN) || polled.revents & POLLPRI) {
-    handlePollin(polled.fd, type);
+    handlePollin(polled.fd, Type);
   }
   if (polled.revents & POLLOUT) {
-    handlePollout(polled.fd, type);
+    handlePollout(polled.fd, Type);
   }
   if (polled.revents & POLLRDHUP) {
-    handlePollrdhup(polled.fd, type);
+    handlePollrdhup(polled.fd, Type);
   }
 }
 

--- a/src/server/ServerRun.cpp
+++ b/src/server/ServerRun.cpp
@@ -2,6 +2,7 @@
 #include "Server.hpp"
 
 #include <cerrno>
+#include <cstdlib> // for exit
 #include <cstring>
 #include <unistd.h> // for close
 
@@ -64,10 +65,16 @@ void Server::serveAll(void) {
 void Server::process(void) {
 
   for (std::vector<pollfd>::iterator it = _fds.begin(); it != _fds.end();) {
-    handleCondition(*it); // sets conditions in client Connection, or accepts
+  	int type = getSocketType(it->fd);
+  	if (type != IS_CLIENT && type != IS_FWD) {
+    	logging::log3(logging::Error, "handleCondition(): fd ", it->fd,
+                  "is not found in _clientMap or _fwdMap.");
+    	exit (1);
+  	}
+    handleCondition(*it, type); // sets conditions in client Connection, or accepts
                           // new connections
-    if (shouldBeDeleted(it->fd) == true) {
-      closeAndDelete(it->fd);
+    if (shouldBeDeleted(it->fd, type) == true) {
+      closeAndDelete(it->fd, type);
       it = _fds.erase(it);
       continue;
     }
@@ -79,7 +86,7 @@ void Server::process(void) {
   _newFdBatch.clear();
 }
 
-void Server::closeAndDelete(int Fd) {
+void Server::closeAndDelete(int Fd, int type) {
 
   close(Fd);
   if (socketIsClient(Fd))
@@ -88,32 +95,22 @@ void Server::closeAndDelete(int Fd) {
     _fwdMap.erase(Fd);
 }
 
-bool Server::shouldBeDeleted(int Fd) {
-  if (socketIsClient(Fd) && _clientMap.at(Fd).getDeleteStatus() == true) {
-    return (true);
+/* shouldBeDeleted is called only by Server::process, which
+	guarantees that Type will be IS_CLINET or IS_FWD */
+
+bool Server::shouldBeDeleted(int Fd, int Type) {
+  if (Type == IS_CLIENT){
+	return (_clientMap.at(Fd).getDeleteStatus());
   }
-  int clientFd;
-  try {
-    clientFd = _fwdMap.at(Fd)->getSock();
-  } catch (std::out_of_range &e) {
-    logging::log3(logging::Error, "shouldBeDeleted(): Fd ", Fd,
-                  "not found in _clientMap or _fwdMap"
-                  "This should never happen.");
-    return (false);
+  else if (Type == IS_FWD) {
+  	int clientFd = _fwdMap.at(Fd)->getSock();
+  	return (_clientMap.at(clientFd).getDeleteStatus());
   }
-  try {
-    if (_clientMap.at(clientFd).getDeleteStatus() == true) {
-      return (true);
-    }
-  } catch (std::out_of_range &e) {
-    logging::log3(logging::Error, "shouldBeDeleted(): Fd ", Fd,
-                  " is fwd socket"
-                  "associated with client socket ");
-    logging::log2(logging::Error, clientFd,
-                  ", not found in _clientMap. Should never happen");
-    return (false);
-  }
-  return (false);
+  else {
+	logging::log(logging::Error, "Server::shouldBeDeleted "
+		"expected IS_CLIENT or IS_FWD fd");
+		exit (1);
+	}
 }
 
 // adds new connection to _clientMap -- move to pollhandling??


### PR DESCRIPTION
feature: extend new method of obtaining Type once and passing through multiple functions. Type is now obtained even earlier, in Process(). Type is now passed to shouldBeDeleted() and closeAndDelete() as well, streamlining logic and avoiding unnecessary map bounds checking. The fd passed to these functions is already assured to be in clientMap or fwdMap, and we don't need to re-check which it belongs to.