### PR TITLE
Timeouts

### DIFF
--- a/inc/CGIProcess.hpp
+++ b/inc/CGIProcess.hpp
@@ -43,11 +43,13 @@ public:
     bool isInputDone() const;
 	int getPid() const ;
     int getForwardSocket() const;
+    time_t  getTimeLastActive() const;
 
     //setters
     void setPid(pid_t Pid);
     void setInputDone(bool Done);
 	void setCGIPath(std::string const &Path);
+    void setTimeLastActive(time_t Time);
     
 private:
    
@@ -65,4 +67,5 @@ private:
     int         _forwardSocket;
     std::string _output;
     bool        _inputDone;
+    time_t      _timeLastActive;
 };

--- a/inc/Connection.hpp
+++ b/inc/Connection.hpp
@@ -33,11 +33,13 @@ public:
   bool getDeleteStatus(void) const;
   Conditions getConditions(void) const;
   int getConditionsWanted(void) const;
+  time_t getTimeLastActive(void) const;
 
   // setters
   void scheduleForDemolition(void);
   void addToConditions(Conditions Condition);
   void resetConditions(void);
+  void setTimeLastActive(time_t Time);
 
   // send & receive
   //void readData(void);
@@ -50,6 +52,8 @@ private:
   Connection(); // should not be possible
 
   void updateConditionsWanted(Reaction::ProcessType ProcessType);
+
+  time_t _timeLastActive;
 
   // serve reads from
   int _conditionsFulfilled;

--- a/inc/Connection.hpp
+++ b/inc/Connection.hpp
@@ -34,22 +34,16 @@ public:
   bool getCgiFinishedStatus(void) const;
   Conditions getConditions(void) const;
   int getConditionsWanted(void) const;
-<<<<<<< HEAD
   time_t getTimeLastActive(void) const;
-=======
   int getConditionsFulfilled(void) const;
->>>>>>> main
 
   // setters
   void scheduleForDemolition(void);
   void scheduleFwdForDemolition(void);
   void addToConditions(Conditions Condition);
   void resetConditions(void);
-<<<<<<< HEAD
   void setTimeLastActive(time_t Time);
-=======
   void resetSockFwd(void);
->>>>>>> main
 
   // send & receive
   //void readData(void);

--- a/inc/NetworkingDefines.hpp
+++ b/inc/NetworkingDefines.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-//#define PORT "3490"      // will later be determined by config file (argv[1]);
 #define MAX_REQUEST 1024 // will later be determined by config file
 #define BACKLOG 10
 #define BYTES_PER_CHUNK 1024
+#define TIMEOUT 60 // seconds of inactivity before client is marked for deletion

--- a/inc/NetworkingDefines.hpp
+++ b/inc/NetworkingDefines.hpp
@@ -4,3 +4,4 @@
 #define BACKLOG 10
 #define BYTES_PER_CHUNK 1024
 #define TIMEOUT 60 // seconds of inactivity before client is marked for deletion
+#define CGI_TIMEOUT 3 // seconds of inactivity (not sending anything to buffer) before CGI process is killed

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -80,7 +80,7 @@ class Server {
 
 	// ServerHandlePoll.hpp
 	//bool reventsAreTerminal(int revents);
-	void handleCondition(struct pollfd &Polled, int Type);
+	void handleCondition(struct pollfd &Polled, int Type, time_t TimeNow);
 	//void handleTerminalCondition(struct pollfd &polled);
 	//void handleServableCondition(struct pollfd &polled);
 	

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -77,7 +77,7 @@ class Server {
 	short	 determineEventsClient(int Fd);
 	short  determineEventsFwd(int Fd);
 	bool shouldBeDeleted(int Fd, int Type);
-	void checkForNewCGI(int Fd);
+	bool newCGISocketAdded(int Fd);
 	//void closeAndDelete(int Fd, int Type); //currently not in use
 	void addConnectionToMap(int ListenerFd, const struct ClientAddr &Candidate);
 	short getForwardEvents(int ConditionsWanted);

--- a/src/connection/Connection.cpp
+++ b/src/connection/Connection.cpp
@@ -31,6 +31,7 @@ Connection::Connection(const int Sock, const sockaddr_storage &Addr,
   memset(&_info, 0, sizeof _info); // unneccessary? delete?
   memcpy(&_addr, &Addr, Addr_size);
   memset(&_readBuf, 0, MAX_REQUEST);
+  _timeLastActive = time(NULL);
   logging::log(logging::Debug, "Connection created");
 }
 
@@ -51,6 +52,10 @@ bool Connection::getDeleteStatus(void) const {
   return (_delete);
 }
 
+time_t Connection::getTimeLastActive(void) const {
+  return (_timeLastActive);
+}
+
 /*
 Conditions Connection::getConditions(void) const {
   if (_req.getState() == COMPLETE)
@@ -66,6 +71,10 @@ int Connection::getConditionsWanted(void) const {
 // Setters
 void Connection::scheduleForDemolition(void) {
   _delete = true;
+}
+
+void Connection::setTimeLastActive(time_t Time) {
+  _timeLastActive = Time;
 }
 
 void Connection::updateConditionsWanted(Reaction::ProcessType ProcessType){

--- a/src/connection/Connection.cpp
+++ b/src/connection/Connection.cpp
@@ -123,6 +123,7 @@ void Connection::serve(void) {
 		&& _req.getState() != COMPLETE && _req.getState() != INVALID)
 		_req.process(_sock);
 	if (_req.getState() == CLIENTHUNGUP){
+		logging::log2(logging::Debug, getSock(), " scheduleForDemolition() in Connection::serve because CLIENTHUNGUP()");
 		scheduleForDemolition();
 		return ;
 	};
@@ -138,6 +139,7 @@ void Connection::serve(void) {
 	//we do not need the CGI sockets handed over here, as they are set in Reaction itself
 	else if(_react.process(_sock, BYTES_PER_CHUNK, _conditionsFulfilled)){
 		// returns true if the creation and sending of the process is done
+		logging::log2(logging::Debug, getSock(), " scheduleForDemolition() in Connection::serve()");
 		scheduleForDemolition();
 	}
 	//update ConditionsWanted here - from Reaction

--- a/src/connection/Connection.cpp
+++ b/src/connection/Connection.cpp
@@ -136,8 +136,10 @@ void Connection::serve(void) {
 	}
 	// we have a initialized Reaction - act on it.
 	//we do not need the CGI sockets handed over here, as they are set in Reaction itself
-	else if(_react.process(_sock, BYTES_PER_CHUNK, _conditionsFulfilled)) // returns only true if the creation and sending of the process is done
+	else if(_react.process(_sock, BYTES_PER_CHUNK, _conditionsFulfilled)){
+		// returns true if the creation and sending of the process is done
 		scheduleForDemolition();
+	}
 	//update ConditionsWanted here - from Reaction
 	//before process is called in the next round
 	updateConditionsWanted(_react.getProcessType());

--- a/src/reaction/CGIProcess.cpp
+++ b/src/reaction/CGIProcess.cpp
@@ -57,6 +57,9 @@ int CGIProcess::getPid() const {
 	return _pid;
 }
 
+time_t CGIProcess::getTimeLastActive(void) const {
+  return (_timeLastActive);
+}
 
 void CGIProcess::setPid(pid_t Pid){
 	_pid = Pid;
@@ -64,6 +67,10 @@ void CGIProcess::setPid(pid_t Pid){
 
 void CGIProcess::setInputDone(bool Done){
 	_inputDone = Done;
+}
+
+void CGIProcess::setTimeLastActive(time_t Time) {
+  _timeLastActive = Time;
 }
 
 void CGIProcess::setCGIPath(std::string const &Path){
@@ -222,6 +229,7 @@ bool CGIProcess::init(Request Req, Script Script, std::string const &Path, int &
 	
 	if (!initForwardSocket(ForwardSocket))
 		return (false);
-	
+
+	_timeLastActive = time(NULL);
     return true;
 }

--- a/src/reaction/ReactionProcess.cpp
+++ b/src/reaction/ReactionProcess.cpp
@@ -69,11 +69,14 @@ bool Reaction::process(const int Socket, const size_t Bytes, const int Condition
 }
 
 bool Reaction::checkOnChild(void){
-	
+
+	//logging::log(logging::Debug, "checkOnChild()");
 	const pid_t pid = _cgi.getPid();
 	if (pid == -1) // no CGI
 		return true;
-	if (time(NULL) - _cgi.getTimeLastActive() > CGI_TIMEOUT) {
+	time_t timeElapsed = time(NULL) - _cgi.getTimeLastActive();
+	//logging::log2(logging::Debug, "CGI time elapsed: ", timeElapsed);
+	if (timeElapsed > CGI_TIMEOUT) {
 		logging::log(logging::Debug, "CGI timed out.");
 		kill(pid, SIGKILL);
 		_cgi.setPid(-1);
@@ -140,6 +143,7 @@ void Reaction::receiveFromCGI(const size_t Bytes){
 	logging::log2(logging::Debug, "receiveFromCGI - receiving from fd: ", _cgi.getForwardSocket());
 	const ssize_t rc = _buffer.fileToBuf(_cgi.getForwardSocket(), Bytes);
 	//const ssize_t rc = _buffer.fileToBuf(5, Bytes);
+	logging::log2(logging::Debug, "In receiveFromCGI(), rc = ", rc);
 	if (rc < 0){ // when buffer is full
 		return ;
 	}

--- a/src/reaction/ReactionProcess.cpp
+++ b/src/reaction/ReactionProcess.cpp
@@ -3,6 +3,7 @@
 #include "Buffer.hpp"
 #include "Conditions.hpp"
 #include "Logging.hpp"
+#include "NetworkingDefines.hpp"
 #include "StatusCodes.hpp"
 #include <algorithm>
 #include <cerrno>
@@ -72,10 +73,17 @@ bool Reaction::checkOnChild(void){
 	const pid_t pid = _cgi.getPid();
 	if (pid == -1) // no CGI
 		return true;
+	if (time(NULL) - _cgi.getTimeLastActive() > CGI_TIMEOUT) {
+		logging::log(logging::Debug, "CGI timed out.");
+		kill(pid, SIGKILL);
+		_cgi.setPid(-1);
+		initSendError(CODE_500);
+		return false;
+	}
   
   	int status;
 	const pid_t result = waitpid(pid, &status, WNOHANG);
-	
+
   	if (result == -1){
     	_cgi.setPid(-1);
 		initSendError(CODE_500);
@@ -139,6 +147,9 @@ void Reaction::receiveFromCGI(const size_t Bytes){
 		// EOF from forwardSocket transition to SendFile from remaining buffer
 		_fdIn = -1;
 		_processType = SendFile;
+	}
+	else {
+		_cgi.setTimeLastActive(time(NULL));
 	}
 }
 

--- a/src/server/ServerHandlePoll.cpp
+++ b/src/server/ServerHandlePoll.cpp
@@ -17,7 +17,7 @@
 
 /////////////////////////////////////////////////////////////////////////
 
-void Server::handleCondition(struct pollfd &polled, int Type) {
+void Server::handleCondition(struct pollfd &polled, int Type, time_t TimeNow) {
   	
   if (polled.revents & POLLNVAL) {
     handlePollnval(polled.fd, Type);
@@ -33,9 +33,15 @@ void Server::handleCondition(struct pollfd &polled, int Type) {
   }
   if ((polled.revents & POLLIN) || polled.revents & POLLPRI) {
     handlePollin(polled.fd, Type);
+    if (Type == IS_CLIENT) {
+      _clientMap.at(polled.fd).setTimeLastActive(TimeNow);
+    }
   }
   if (polled.revents & POLLOUT) {
     handlePollout(polled.fd, Type);
+    if (Type == IS_CLIENT) {
+      _clientMap.at(polled.fd).setTimeLastActive(TimeNow);
+    }
   }
   if (polled.revents & POLLRDHUP) {
     handlePollrdhup(polled.fd, Type);

--- a/src/server/ServerHandlePoll.cpp
+++ b/src/server/ServerHandlePoll.cpp
@@ -17,14 +17,9 @@
 
 /////////////////////////////////////////////////////////////////////////
 
-<<<<<<< HEAD
 void Server::handleCondition(struct pollfd &polled, int Type, time_t TimeNow) {
-  	
-=======
-void Server::handleCondition(struct pollfd &polled, int Type) {
   
->>>>>>> main
-  if (polled.revents & POLLNVAL) {
+	if (polled.revents & POLLNVAL) {
     handlePollnval(polled.fd, Type);
     return;
   }

--- a/src/server/ServerHandlePollErrs.cpp
+++ b/src/server/ServerHandlePollErrs.cpp
@@ -80,7 +80,8 @@ void Server::handlePollnval(int Fd, int Type) {
   if (Type == IS_CLIENT) {
     logging::log2(logging::Error, Fd, " is a client socket");
     //markClientDeletion(Fd);
-	_fwdMap.at(Fd)->scheduleForDemolition();
+		logging::log2(logging::Debug, Fd, " scheduleForDemolition() in handlePollnval()");
+	  _fwdMap.at(Fd)->scheduleForDemolition();
 	return;
   }
   if (Type == IS_FWD) {
@@ -111,6 +112,7 @@ void Server::handlePollhup(int Fd, int Type) {
                 " fd = ",
                 Fd);
   if (Type == IS_CLIENT) {
+		logging::log2(logging::Debug, Fd, " scheduleForDemolition() in handlePollhup()");
     _clientMap.at(Fd).scheduleForDemolition();
   } else if (Type == IS_FWD) {
     logging::log3(logging::Debug,
@@ -141,6 +143,7 @@ void Server::handlePollerr(int Fd, int Type) {
   if (Type == IS_CLIENT) {
     logging::log2(logging::Error, Fd, " is a client socket");
     //markClientDeletion(Fd);
+		logging::log2(logging::Debug, Fd, " scheduleForDemolition() in handlePollerr()");
     _clientMap.at(Fd).scheduleForDemolition();
     return;
   }

--- a/src/server/ServerRun.cpp
+++ b/src/server/ServerRun.cpp
@@ -23,8 +23,7 @@ void Server::pollLoop(void) {
 
   while (1) {
     const int res =
-        poll(_fds.data(), (nfds_t)_fds.size(),
-             -1); // without restriction to _fds.size this cast is unsafe
+        poll(_fds.data(), (nfds_t)_fds.size(), TIMEOUT * 1000); // without restriction to _fds.size this cast is unsafe
     // logging::log(logging::Debug, "poll()");
     if (res == -1) {
       std::ostringstream msg;
@@ -66,15 +65,22 @@ void Server::process(void) {
 
   for (std::vector<pollfd>::iterator it = _fds.begin(); it != _fds.end();) {
   	int type = getSocketType(it->fd);
-    handleCondition(*it, type); // sets conditions in client Connection, or accepts
+    time_t timeNow = time(NULL);
+    handleCondition(*it, type, timeNow); // sets conditions in client Connection, or accepts
                           // new connections
+  if (type == IS_CLIENT && timeNow - _clientMap.at(it->fd).getTimeLastActive() >= TIMEOUT){
+    logging::log3(logging::Debug, "Connection timeout. Fd, seconds:", it->fd, TIMEOUT);
+    closeAndDelete(it->fd, type);
+    it = _fds.erase(it);
+    continue;
+  }
 	if (type != IS_LISTENER && shouldBeDeleted(it->fd, type) == true) {
       closeAndDelete(it->fd, type);
       it = _fds.erase(it);
       continue;
     }
 	if (type == IS_CLIENT){
-		checkForNewCGI(it->fd);	
+    checkForNewCGI(it->fd);	
 	}
     it->revents = 0;
     it++;

--- a/src/server/ServerRun.cpp
+++ b/src/server/ServerRun.cpp
@@ -63,9 +63,9 @@ void Server::serveAll(void) {
 
 void Server::process(void) {
 
+  time_t timeNow = time(NULL);
   for (std::vector<pollfd>::iterator it = _fds.begin(); it != _fds.end();) {
   	int type = getSocketType(it->fd);
-    time_t timeNow = time(NULL);
     handleCondition(*it, type, timeNow); // sets conditions in client Connection, or accepts
                           // new connections
   if (type == IS_CLIENT && timeNow - _clientMap.at(it->fd).getTimeLastActive() >= TIMEOUT){

--- a/src/server/ServerRun.cpp
+++ b/src/server/ServerRun.cpp
@@ -64,7 +64,7 @@ void Server::serveAll(void) {
 void Server::process(void) {
 
   // sleep(1); // can be used to slow down loop for debugging
-  logging::log(logging::Warning, "Process");
+  logging::log(logging::Debug, "Process");
   time_t timeNow = time(NULL);
   for (std::vector<pollfd>::iterator it = _fds.begin(); it != _fds.end();) {
     
@@ -72,17 +72,15 @@ void Server::process(void) {
     handleCondition(*it, type, timeNow); // sets conditions in client Connection, or accepts
                           // new connections
     std::cout << getFdInfoString(*it, it->fd, type);
-  if (type == IS_CLIENT && timeNow - _clientMap.at(it->fd).getTimeLastActive() >= TIMEOUT){
-    logging::log3(logging::Debug, "Connection timeout. Fd, seconds:", it->fd, TIMEOUT);
-    closeAndDelete(it->fd, type);
-    it = _fds.erase(it);
-    continue;
-  }
 	if (type != IS_LISTENER && shouldBeDeleted(it->fd, type) == true) {
     _deleteFdBatch.insert(std::make_pair(it->fd, type));
   }
 	else if (type == IS_CLIENT){
-		checkForNewCGI(it->fd);	
+		if (newCGISocketAdded(it->fd) != true){
+      if (type == IS_CLIENT && timeNow - _clientMap.at(it->fd).getTimeLastActive() >= TIMEOUT){
+        _clientMap.at(it->fd).scheduleForDemolition();
+      }
+    }
 	}
     it->revents = 0;
     it++;
@@ -94,11 +92,11 @@ void Server::process(void) {
   _newFdBatch.clear();
 }
 
-void Server::checkForNewCGI(int Fd) {
+bool Server::newCGISocketAdded(int Fd) {
 	Connection *connection  = &_clientMap.at(Fd);
 	//int potentialNewSocket = clientMap.at(Fd)->_socketForward;
   if (connection->getCgiFinishedStatus() == true) {
-    return;
+    return false;
   }
 	int fwdSock = connection->getSockForward();
 	if (fwdSock != -1 && _fwdMap.find(fwdSock) == _fwdMap.end()) {
@@ -106,7 +104,9 @@ void Server::checkForNewCGI(int Fd) {
 		_fwdMap.insert(std::make_pair(fwdSock, connection));
     const pollfd newFd = {fwdSock, determineEventsFwd(connection->getConditionsWanted()), 0};
     _newFdBatch.push_back(newFd);
+    return true;
 	}
+  return false;
 }
 
 void Server::updateEvents(void){

--- a/src/server/ServerRun.cpp
+++ b/src/server/ServerRun.cpp
@@ -64,24 +64,25 @@ void Server::serveAll(void) {
 void Server::process(void) {
 
   // sleep(1); // can be used to slow down loop for debugging
-  logging::log(logging::Debug, "Process");
+  //logging::log(logging::Debug, "Process");
   time_t timeNow = time(NULL);
   for (std::vector<pollfd>::iterator it = _fds.begin(); it != _fds.end();) {
     
   	int type = getSocketType(it->fd);
     handleCondition(*it, type, timeNow); // sets conditions in client Connection, or accepts
                           // new connections
-    std::cout << getFdInfoString(*it, it->fd, type);
-	if (type != IS_LISTENER && shouldBeDeleted(it->fd, type) == true) {
-    _deleteFdBatch.insert(std::make_pair(it->fd, type));
-  }
-	else if (type == IS_CLIENT){
+    //std::cout << getFdInfoString(*it, it->fd, type);
+	if (type == IS_CLIENT){
 		if (newCGISocketAdded(it->fd) != true){
       if (type == IS_CLIENT && timeNow - _clientMap.at(it->fd).getTimeLastActive() >= TIMEOUT){
+		  logging::log2(logging::Debug, it->fd, " scheduleForDemolition() in Server::process()");
         _clientMap.at(it->fd).scheduleForDemolition();
       }
     }
 	}
+	if (type != IS_LISTENER && shouldBeDeleted(it->fd, type) == true) {
+    _deleteFdBatch.insert(std::make_pair(it->fd, type));
+  }
     it->revents = 0;
     it++;
   }


### PR DESCRIPTION
Timeouts implemented.

Includes changes to NetworkingDefines.hpp, Server::poll(), Server::process(), and Server::handleConditions(). How it works:

1. Connections now contain a time_t _timeLastActive, which is first set by calling time() when the Connection is created.

2. In NetworkingDefines.hpp: we now have a macro TIMEOUT (currently set to 60 seconds)

3. When we call poll, we are now making use of the third argument:
       int poll(struct pollfd *fds, nfds_t nfds, int timeout);

Previously, timeout was set to -1 in poll(), meaning no timeout. No timeout meant poll() would wait until it detected activity / readiness  from a client, instead of running needlessly through the process() loop.

Now, poll() now waits only TIMEOUT seconds, at which point we proceed with processing regardless of whether any of the clients are ready to do anything.

4. In Server::process(), the first thing we now do, before we enter for the for loop, is: get a t_time timeNow, representing the current time. For each fd, this time is passed to handleCondition(), where the results of poll are handled and the Connection's conditions are set... If the fd represents a client, and we have activity (POLLIN or POLLOUT), the Connection's _timeLastActive is updated with the new timestamp.

Back in process(), immediately after we call handleCondition(), we check how much time has lapsed between timeNow and the time the client was last active. If they've been inactive for TIMEOUT amount of time, we close their file descriptor, delete them from the clientMap, and delete their fd from the pollfd vector.

I was originally concerned that this approach would unfairly disconnect clients in cases where CGI took more than TIMEOUT seconds to send a response, but actually we're still polling for POLLOUT while CGI runs, so we'll be seeing activity from the client for as long as they're connected and waiting for our response.