### PR TITLE
Fwd socket bug fix

### DIFF
--- a/inc/Connection.hpp
+++ b/inc/Connection.hpp
@@ -31,7 +31,7 @@ public:
   int getSock(void) const;
   int getSockForward(void) const;
   bool getDeleteStatus(void) const;
-  bool getDeleteFwdStatus(void) const;
+  bool getCgiFinishedStatus(void) const;
   Conditions getConditions(void) const;
   int getConditionsWanted(void) const;
 

--- a/inc/Connection.hpp
+++ b/inc/Connection.hpp
@@ -31,11 +31,13 @@ public:
   int getSock(void) const;
   int getSockForward(void) const;
   bool getDeleteStatus(void) const;
+  bool getDeleteFwdStatus(void) const;
   Conditions getConditions(void) const;
   int getConditionsWanted(void) const;
 
   // setters
   void scheduleForDemolition(void);
+  void scheduleFwdForDemolition(void);
   void addToConditions(Conditions Condition);
   void resetConditions(void);
 
@@ -61,6 +63,7 @@ private:
 
   // networking
   bool _delete; // set by scheduleForDemolition
+  bool _deleteFwd;
   struct addrinfo _info;
   struct sockaddr_storage _addr; // client's IP
   socklen_t _addrSize;

--- a/inc/Connection.hpp
+++ b/inc/Connection.hpp
@@ -40,6 +40,7 @@ public:
   void scheduleFwdForDemolition(void);
   void addToConditions(Conditions Condition);
   void resetConditions(void);
+  void resetSockFwd(void);
 
   // send & receive
   //void readData(void);

--- a/inc/Connection.hpp
+++ b/inc/Connection.hpp
@@ -64,7 +64,9 @@ private:
 
   // networking
   bool _delete; // set by scheduleForDemolition
-  bool _deleteFwd;
+  bool _cgiFinished;
+  // _cgiFinished, aka "_deleteFwd"
+  // renamed because it is still used after the forward socket has already been deleted
   struct addrinfo _info;
   struct sockaddr_storage _addr; // client's IP
   socklen_t _addrSize;

--- a/inc/Connection.hpp
+++ b/inc/Connection.hpp
@@ -34,6 +34,7 @@ public:
   bool getCgiFinishedStatus(void) const;
   Conditions getConditions(void) const;
   int getConditionsWanted(void) const;
+  int getConditionsFulfilled(void) const;
 
   // setters
   void scheduleForDemolition(void);

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -39,6 +39,8 @@ class Server {
         IS_FWD,
 		IS_LISTENER
     };
+
+
 	
 	// variables
 	addrinfo _hints; // our specifications for getaddrinfo
@@ -49,6 +51,7 @@ class Server {
 //	std::map<int, Connection&> _cgiWriteMap;
 //	std::map<int, Connection&> _cgiReadMap;
 	std::vector<pollfd> _newFdBatch;
+	std::map<int, int> _deleteFdBatch;
 	std::map<std::string, bool> _pairsInUse; // listening <IP:Port>
 
 	// ServerInit.hpp -- set up listening sockets, pollfds, listenMap
@@ -78,6 +81,7 @@ class Server {
 	void closeAndDelete(int Fd, int Type);
 	void addConnectionToMap(int ListenerFd, const struct ClientAddr &Candidate);
 	short getForwardEvents(int ConditionsWanted);
+	void closeAndDeleteBatch(void);
 
 	// ServerHandlePoll.hpp
 	//bool reventsAreTerminal(int revents);

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -77,6 +77,7 @@ class Server {
 	void checkForNewCGI(int Fd);
 	void closeAndDelete(int Fd, int Type);
 	void addConnectionToMap(int ListenerFd, const struct ClientAddr &Candidate);
+	short getForwardEvents(int ConditionsWanted);
 
 	// ServerHandlePoll.hpp
 	//bool reventsAreTerminal(int revents);

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -111,5 +111,9 @@ class Server {
 	std::string addrinfoToStr(const struct addrinfo *Info, const std::string &Msg);
 	std::string interfaceInfoToStr(const Listen &Interface);
 	void printFcntlFlags(const int Sock);
-
+	std::string getFdInfoString(pollfd &it, int Fd, int Type); 
+	std::string getTypeString(int Type);
+	std::string getConditionsWantedString(int CWanted);
+	std::string getEventsString(short Events);
+	std::string getReventsString(short Revents);
 };

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -89,7 +89,6 @@ class Server {
 	void handlePollerr(int Fd, int Type);
 	void handlePollhup(int Fd, int Type);
 	void markClientDeletion(int Fd);
-	void markFwdDeletion(int Fd);
 
 	// ServerHandlPollin.hpp
 	void handlePollin(int Fd, int Type);

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -78,7 +78,7 @@ class Server {
 	short  determineEventsFwd(int Fd);
 	bool shouldBeDeleted(int Fd, int Type);
 	void checkForNewCGI(int Fd);
-	void closeAndDelete(int Fd, int Type);
+	//void closeAndDelete(int Fd, int Type); //currently not in use
 	void addConnectionToMap(int ListenerFd, const struct ClientAddr &Candidate);
 	short getForwardEvents(int ConditionsWanted);
 	void closeAndDeleteBatch(void);
@@ -115,7 +115,7 @@ class Server {
 	std::string addrinfoToStr(const struct addrinfo *Info, const std::string &Msg);
 	std::string interfaceInfoToStr(const Listen &Interface);
 	void printFcntlFlags(const int Sock);
-	std::string getFdInfoString(pollfd &it, int Fd, int Type); 
+	std::string getFdInfoString(pollfd &It, int Fd, int Type); 
 	std::string getTypeString(int Type);
 	std::string getConditionsWantedString(int CWanted);
 	std::string getConditionsFulfilledString(int CFulfilled);

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -114,6 +114,7 @@ class Server {
 	std::string getFdInfoString(pollfd &it, int Fd, int Type); 
 	std::string getTypeString(int Type);
 	std::string getConditionsWantedString(int CWanted);
+	std::string getConditionsFulfilledString(int CFulfilled);
 	std::string getEventsString(short Events);
 	std::string getReventsString(short Revents);
 };

--- a/scripts/date.py
+++ b/scripts/date.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 
 from datetime import datetime
 

--- a/src/connection/Connection.cpp
+++ b/src/connection/Connection.cpp
@@ -68,6 +68,10 @@ int Connection::getConditionsWanted(void) const {
   return _conditionsWanted;
 }
 
+int Connection::getConditionsFulfilled(void) const {
+  return _conditionsFulfilled;
+}
+
 // Setters
 void Connection::scheduleForDemolition(void) {
   _delete = true;

--- a/src/connection/Connection.cpp
+++ b/src/connection/Connection.cpp
@@ -27,7 +27,7 @@
 Connection::Connection(const int Sock, const sockaddr_storage &Addr,
                        const socklen_t Addr_size, const Website &website)
     : _conditionsWanted(SockRead), _sock(Sock), _sockForward(-1), _website(website), 
-	_delete(false), _deleteFwd(false), _addrSize(sizeof _addr)  {
+	_delete(false), _cgiFinished(false), _addrSize(sizeof _addr)  {
 
   memset(&_info, 0, sizeof _info); // unneccessary? delete?
   memcpy(&_addr, &Addr, Addr_size);
@@ -53,7 +53,7 @@ bool Connection::getDeleteStatus(void) const {
 }
 
 bool Connection::getDeleteFwdStatus(void) const {
-  return (_deleteFwd);
+  return (_cgiFinished);
 }
 
 /*
@@ -74,7 +74,7 @@ void Connection::scheduleForDemolition(void) {
 }
 
 void Connection::scheduleFwdForDemolition(void) {
-  _deleteFwd = true;
+  _cgiFinished = true;
 }
 
 void Connection::resetSockFwd(void) {

--- a/src/connection/Connection.cpp
+++ b/src/connection/Connection.cpp
@@ -27,7 +27,7 @@
 Connection::Connection(const int Sock, const sockaddr_storage &Addr,
                        const socklen_t Addr_size, const Website &website)
     : _conditionsWanted(SockRead), _sock(Sock), _sockForward(-1), _website(website), 
-	_delete(false), _addrSize(sizeof _addr)  {
+	_delete(false), _deleteFwd(false), _addrSize(sizeof _addr)  {
 
   memset(&_info, 0, sizeof _info); // unneccessary? delete?
   memcpy(&_addr, &Addr, Addr_size);
@@ -52,6 +52,10 @@ bool Connection::getDeleteStatus(void) const {
   return (_delete);
 }
 
+bool Connection::getDeleteFwdStatus(void) const {
+  return (_deleteFwd);
+}
+
 /*
 Conditions Connection::getConditions(void) const {
   if (_req.getState() == COMPLETE)
@@ -67,6 +71,10 @@ int Connection::getConditionsWanted(void) const {
 // Setters
 void Connection::scheduleForDemolition(void) {
   _delete = true;
+}
+
+void Connection::scheduleFwdForDemolition(void) {
+  _deleteFwd = true;
 }
 
 void Connection::updateConditionsWanted(Reaction::ProcessType ProcessType){

--- a/src/connection/Connection.cpp
+++ b/src/connection/Connection.cpp
@@ -52,7 +52,7 @@ bool Connection::getDeleteStatus(void) const {
   return (_delete);
 }
 
-bool Connection::getDeleteFwdStatus(void) const {
+bool Connection::getCgiFinishedStatus(void) const {
   return (_cgiFinished);
 }
 

--- a/src/connection/Connection.cpp
+++ b/src/connection/Connection.cpp
@@ -77,6 +77,10 @@ void Connection::scheduleFwdForDemolition(void) {
   _deleteFwd = true;
 }
 
+void Connection::resetSockFwd(void) {
+  _sockForward = -1;
+}
+
 void Connection::updateConditionsWanted(Reaction::ProcessType ProcessType){
 	switch (ProcessType){
 		case Reaction::SendFile:

--- a/src/reaction/CGIProcess.cpp
+++ b/src/reaction/CGIProcess.cpp
@@ -201,6 +201,9 @@ bool CGIProcess::initForwardSocket(int & ForwardSocket) {
     // Parent
     close(sv[1]);
     ForwardSocket = sv[0];
+	_forwardSocket = sv[0]; // Adding this line to also set CGIProcess._forwardSocket
+	// Networking is accessing ForwardSocket(a member of Connection that has been passed through a chain of functions)
+	// However, Buffer::fileToBuf() sends to _fowardSocket
 
     return true;
 }

--- a/src/reaction/ReactionProcess.cpp
+++ b/src/reaction/ReactionProcess.cpp
@@ -137,8 +137,8 @@ void Reaction::receiveFromCGI(const size_t Bytes){
 	// fill buffer from CGI socket — FSockRead guarantees data is available
 	_buffer.optimize(Bytes);
 	logging::log2(logging::Debug, "receiveFromCGI - receiving from fd: ", _cgi.getForwardSocket());
-	//const ssize_t rc = _buffer.fileToBuf(_cgi.getForwardSocket(), Bytes);
-	const ssize_t rc = _buffer.fileToBuf(5, Bytes);
+	const ssize_t rc = _buffer.fileToBuf(_cgi.getForwardSocket(), Bytes);
+	//const ssize_t rc = _buffer.fileToBuf(5, Bytes);
 	if (rc < 0){ // when buffer is full
 		return ;
 	}

--- a/src/reaction/ReactionProcess.cpp
+++ b/src/reaction/ReactionProcess.cpp
@@ -137,7 +137,8 @@ void Reaction::receiveFromCGI(const size_t Bytes){
 	// fill buffer from CGI socket — FSockRead guarantees data is available
 	_buffer.optimize(Bytes);
 	logging::log2(logging::Debug, "receiveFromCGI - receiving from fd: ", _cgi.getForwardSocket());
-	const ssize_t rc = _buffer.fileToBuf(_cgi.getForwardSocket(), Bytes);
+	//const ssize_t rc = _buffer.fileToBuf(_cgi.getForwardSocket(), Bytes);
+	const ssize_t rc = _buffer.fileToBuf(5, Bytes);
 	if (rc < 0){ // when buffer is full
 		return ;
 	}

--- a/src/reaction/ReactionProcess.cpp
+++ b/src/reaction/ReactionProcess.cpp
@@ -136,6 +136,7 @@ void Reaction::receiveFromCGI(const size_t Bytes){
 
 	// fill buffer from CGI socket — FSockRead guarantees data is available
 	_buffer.optimize(Bytes);
+	logging::log2(logging::Debug, "receiveFromCGI - receiving from fd: ", _cgi.getForwardSocket());
 	const ssize_t rc = _buffer.fileToBuf(_cgi.getForwardSocket(), Bytes);
 	if (rc < 0){ // when buffer is full
 		return ;

--- a/src/request/Request.cpp
+++ b/src/request/Request.cpp
@@ -83,7 +83,7 @@ std::vector<std::string> split(const std::string& S, const std::string& Delimite
 		last = next + Delimiter.length();
     }
     tokens.push_back(S.substr(last)); 
-	logging::log(logging::Debug, "split Successfull");
+	//logging::log(logging::Debug, "split Successfull");
     return tokens;
 }
 

--- a/src/server/ServerDebug.cpp
+++ b/src/server/ServerDebug.cpp
@@ -41,6 +41,110 @@ std::string Server::interfaceInfoToStr(const Listen &Interface) {
   return (msg.str());
 }
 
+std::string Server::getTypeString(int Type){
+  if (Type == IS_CLIENT) {
+    return ("client");
+  }
+  else if (Type == IS_FWD) {
+    return ("forward");
+  }
+  else if (Type == IS_LISTENER) {
+    return ("listener");
+  }
+  else {
+    return ("nonsense");
+  }
+}
+
+std::string Server::getConditionsWantedString(int CWanted){
+  std::ostringstream wanted;
+  if (CWanted & SockRead) {
+    wanted << "SockRead ";
+  }
+  if (CWanted & SockWrite) {
+    wanted << "SockWrite ";
+  }
+  if (CWanted & FSockRead) {
+    wanted << "FSockRead ";
+  }
+  if (CWanted & FSockWrite) {
+    wanted << "FSockWrite ";
+  }
+  return (wanted.str());
+}
+
+std::string Server::getEventsString(short Events){
+  std::ostringstream msg;
+  if (Events & POLLNVAL) {
+    msg << "POLLNVAL ";
+  }
+  if (Events & POLLERR) {
+    msg << "POLLERR ";
+  }
+  if (Events & POLLIN) {
+    msg << "POLLIN ";
+  }
+  if (Events & POLLOUT) {
+    msg << "POLLOUT ";
+  }
+  if (Events & POLLRDHUP) {
+    msg << "POLLRDHUP ";
+  }
+  if (Events & POLLHUP) {
+    msg << "POLLHUP ";
+  }
+  return (msg.str());
+}
+
+std::string Server::getReventsString(short Revents){
+  std::ostringstream msg;
+  if (Revents & POLLNVAL) {
+    msg << "POLLNVAL ";
+  }
+  if (Revents & POLLERR) {
+    msg << "POLLERR ";
+  }
+  if (Revents & POLLIN) {
+    msg << "POLLIN ";
+  }
+  if (Revents & POLLOUT) {
+    msg << "POLLOUT ";
+  }
+  if (Revents & POLLRDHUP) {
+    msg << "POLLRDHUP ";
+  }
+  if (Revents & POLLHUP) {
+    msg << "POLLHUP ";
+  }
+  return (msg.str());
+}
+
+std::string Server::getFdInfoString(pollfd &it, int Fd, int Type){
+ std::ostringstream msg;
+ msg << "\n"
+ << "\tfd: " << Fd << "\n"
+ <<  "\ttype: " << getTypeString(Type) << "\n";
+ if (Type == IS_CLIENT) {
+    msg << "\t_sockForward = "
+    << _clientMap.at(Fd).getSockForward() << "\n"
+    << "\t_cgiFinished = " << _clientMap.at(Fd).getCgiFinishedStatus()
+    << "\n"
+    << "\t_conditionsWanted: "
+    << getConditionsWantedString(_clientMap.at(Fd).getConditionsWanted())
+    << "\n";
+  }
+  if (Type == IS_FWD){
+    msg << "\tbelongs to client: " << _fwdMap.at(Fd)->getSock() << "\n"
+    << "\t_conditionsWanted: "
+    << getConditionsWantedString(_fwdMap.at(Fd)->getConditionsWanted())
+    << "\n";
+  }
+  msg << "\tevents: " << getReventsString(it.events) << "\n"
+  << "\trevents: " << getReventsString(it.revents)
+  << "\n";
+  return (msg.str());
+}
+
 /*
 void Server::printFcntlFlags(const int Sock) {
   const int flags = fcntl(Sock, F_GETFL);

--- a/src/server/ServerDebug.cpp
+++ b/src/server/ServerDebug.cpp
@@ -55,6 +55,23 @@ std::string Server::getTypeString(int Type){
     return ("nonsense");
   }
 }
+	
+std::string Server::getConditionsFulfilledString(int CFulfilled){
+  std::ostringstream fulfilled;
+  if (CFulfilled & SockRead) {
+    fulfilled << "SockRead ";
+  }
+  if (CFulfilled & SockWrite) {
+    fulfilled << "SockWrite ";
+  }
+  if (CFulfilled & FSockRead) {
+    fulfilled << "FSockRead ";
+  }
+  if (CFulfilled & FSockWrite) {
+    fulfilled << "FSockWrite ";
+  }
+  return (fulfilled.str());
+}
 
 std::string Server::getConditionsWantedString(int CWanted){
   std::ostringstream wanted;
@@ -131,16 +148,22 @@ std::string Server::getFdInfoString(pollfd &it, int Fd, int Type){
     << "\n"
     << "\t_conditionsWanted: "
     << getConditionsWantedString(_clientMap.at(Fd).getConditionsWanted())
+    << "\n"
+    << "\t_conditionsFulfilled: "
+    << getConditionsFulfilledString(_clientMap.at(Fd).getConditionsFulfilled())
     << "\n";
   }
   if (Type == IS_FWD){
     msg << "\tbelongs to client: " << _fwdMap.at(Fd)->getSock() << "\n"
     << "\t_conditionsWanted: "
     << getConditionsWantedString(_fwdMap.at(Fd)->getConditionsWanted())
+    << "\n"
+    << "\t_conditionsFulfilled: "
+    << getConditionsFulfilledString(_fwdMap.at(Fd)->getConditionsFulfilled())
     << "\n";
   }
   msg << "\tevents: " << getReventsString(it.events) << "\n"
-  << "\trevents: " << getReventsString(it.revents)
+  << "\trevents: " << getReventsString(it.revents) << "\n"
   << "\n";
   return (msg.str());
 }

--- a/src/server/ServerHandlePoll.cpp
+++ b/src/server/ServerHandlePoll.cpp
@@ -18,7 +18,7 @@
 /////////////////////////////////////////////////////////////////////////
 
 void Server::handleCondition(struct pollfd &polled, int Type) {
-  	
+  
   if (polled.revents & POLLNVAL) {
     handlePollnval(polled.fd, Type);
     return;

--- a/src/server/ServerHandlePoll.cpp
+++ b/src/server/ServerHandlePoll.cpp
@@ -27,10 +27,6 @@ void Server::handleCondition(struct pollfd &polled, int Type) {
     handlePollerr(polled.fd, Type);
     return;
   }
-  if (polled.revents & POLLHUP) {
-    handlePollhup(polled.fd, Type);
-    return;
-  }
   if ((polled.revents & POLLIN) || polled.revents & POLLPRI) {
     handlePollin(polled.fd, Type);
   }
@@ -39,6 +35,10 @@ void Server::handleCondition(struct pollfd &polled, int Type) {
   }
   if (polled.revents & POLLRDHUP) {
     handlePollrdhup(polled.fd, Type);
+  }
+  if (polled.revents & POLLHUP) {
+    handlePollhup(polled.fd, Type);
+    return;
   }
 }
 

--- a/src/server/ServerHandlePollErrs.cpp
+++ b/src/server/ServerHandlePollErrs.cpp
@@ -115,7 +115,7 @@ void Server::handlePollhup(int Fd, int Type) {
   } else if (Type == IS_FWD) {
     logging::log3(logging::Debug,
                   "networking::handlePollhup(): got POLLHUP from fwd sock ", Fd,
-                  ". Indicates CGI process has exited and socket closed. Marking fo deletion.");
+                  ". Indicates at least one of the socket pairs closed?");
    // _fwdMap.at(Fd)->scheduleFwdForDemolition();
     return;
   }

--- a/src/server/ServerHandlePollErrs.cpp
+++ b/src/server/ServerHandlePollErrs.cpp
@@ -116,7 +116,7 @@ void Server::handlePollhup(int Fd, int Type) {
     logging::log3(logging::Debug,
                   "networking::handlePollhup(): got POLLHUP from fwd sock ", Fd,
                   ". Indicates CGI process has exited and socket closed. Marking fo deletion.");
-    _fwdMap.at(Fd)->scheduleFwdForDemolition();
+   // _fwdMap.at(Fd)->scheduleFwdForDemolition();
     return;
   }
   if (Type == IS_LISTENER) {

--- a/src/server/ServerHandlePollErrs.cpp
+++ b/src/server/ServerHandlePollErrs.cpp
@@ -115,12 +115,9 @@ void Server::handlePollhup(int Fd, int Type) {
   } else if (Type == IS_FWD) {
     logging::log3(logging::Debug,
                   "networking::handlePollhup(): got POLLHUP from fwd sock ", Fd,
-                  ". This is not necessarily an error but interesting to "
-                  "observe when this happens. We may want to implement removal "
-                  "of the fwd sock at this point.");
-    // TODO downgraed this print before submission
-    // TODO remove socket from fwdMap? // use markFwdDeletion?
-  	return;
+                  ". Indicates CGI process has exited and socket closed. Marking fo deletion.");
+    _fwdMap.at(Fd)->scheduleFwdForDemolition();
+    return;
   }
   if (Type == IS_LISTENER) {
     logging::log2(logging::Error, Fd, " is listening socket. This is truly bizarre.");

--- a/src/server/ServerInit.cpp
+++ b/src/server/ServerInit.cpp
@@ -38,7 +38,7 @@ void Server::initNetworking(const std::list<Website> &Websites) {
     // iterate through each IP:port pair of a given website,
     // contained within the Website's Listen struct
     while (itI != interfaces.end()) {
-      logging::log2(logging::Debug, "interface = ", itI->ip + ":" + itI->port);
+      //logging::log2(logging::Debug, "interface = ", itI->ip + ":" + itI->port);
       initListeningSocket(*itI, *itW);
       itI++;
     }
@@ -73,7 +73,7 @@ void Server::initListeningSocket(const Listen &Pair, const Website &Web) {
   freeaddrinfo(serverInfo);
 
   const pollfd newFd = {sock, POLLIN, 0};
-  logging::log2(logging::Debug, "Listening socket created on socket ", sock);
+  //logging::log2(logging::Debug, "Listening socket created on socket ", sock);
   _fds.push_back(newFd);
   _listenMap.insert(std::make_pair(sock, &Web));
   return;
@@ -169,6 +169,6 @@ int Server::getListeningSocket(struct addrinfo *Info, const Listen &Pair) {
     exit(1);
   }
   setToListen(sock);
-  logging::log(logging::Debug, "server found socket. bind: success");
+  // logging::log(logging::Debug, "server found socket. bind: success");
   return (sock);
 }

--- a/src/server/ServerRun.cpp
+++ b/src/server/ServerRun.cpp
@@ -64,12 +64,7 @@ void Server::serveAll(void) {
 
 void Server::process(void) {
 
-  static int increment;
-  increment++;
-  sleep(1);
-  if (increment >= 50){
-    exit(0);
-  }
+  // sleep(1); // can be used to slow down loop for debugging
   logging::log(logging::Warning, "Process");
   for (std::vector<pollfd>::iterator it = _fds.begin(); it != _fds.end();) {
     
@@ -78,16 +73,15 @@ void Server::process(void) {
                           // new connections
     std::cout << getFdInfoString(*it, it->fd, type);
 	if (type != IS_LISTENER && shouldBeDeleted(it->fd, type) == true) {
-      closeAndDelete(it->fd, type);
-      it = _fds.erase(it);
-      continue;
-    }
-	if (type == IS_CLIENT){
+    _deleteFdBatch.insert(std::make_pair(it->fd, type));
+  }
+	else if (type == IS_CLIENT){
 		checkForNewCGI(it->fd);	
 	}
     it->revents = 0;
     it++;
   }
+  closeAndDeleteBatch();
   serveAll();
   _fds.insert(_fds.end(), _newFdBatch.begin(), _newFdBatch.end());
   updateEvents();
@@ -163,6 +157,7 @@ short Server::determineEventsFwd(int ConditionsWanted){
 
 void Server::closeAndDelete(int Fd, int type) {
   // TODO replace helper functions with type check
+  logging::log2(logging::Debug, "closing & deleting Fd: " , Fd);
   close(Fd);
   if (socketIsClient(Fd))
     _clientMap.erase(Fd);
@@ -179,11 +174,14 @@ bool Server::shouldBeDeleted(int Fd, int Type) {
   }
   else if (Type == IS_FWD) {
   	int clientFd = _fwdMap.at(Fd)->getSock();
-    // There are 2 instances where a forward socket should be deleted:
-    // 1. if the forward socket itself is marked for deletion (CGI)
+    // There are 3 instances where a forward socket should be deleted:
+    // 1. if the client has already been deleted (not currently possible)
+    if (_clientMap.find(clientFd) == _clientMap.end())
+      return true;
+    // 2. if the forward socket itself is marked for deletion (CGI)
     if (_clientMap.at(clientFd).getCgiFinishedStatus() == true)
       return true;
-    // 2. if the forward socket's client is marked for deletion
+    // 3. if the forward socket's client is marked for deletion
   	return (_clientMap.at(clientFd).getDeleteStatus());
   }
   else {
@@ -192,6 +190,34 @@ bool Server::shouldBeDeleted(int Fd, int Type) {
 		exit (1);
 	}
 }
+
+void Server::closeAndDeleteBatch(void) {
+  for (std::map<int, int>::iterator it = _deleteFdBatch.begin(); it != _deleteFdBatch.end(); it++) {
+    logging::log3(logging::Debug, it->first, " will be closed and deleted from map of type ", getTypeString(it->second));
+    if (it->second == IS_FWD) {
+      _fwdMap.erase(it->first);
+    }
+    else if (it->second == IS_CLIENT){
+      _clientMap.erase(it->first);
+    }
+    else {
+      logging::log(logging::Error, "Server::closeAndDeleteBatch "
+          "expected IS_CLIENT or IS_FWD");
+        exit (1);
+    }
+    close(it->first);
+  }
+  for (std::vector<pollfd>::iterator it = _fds.begin(); it != _fds.end();) {
+    if (_deleteFdBatch.find(it->fd) != _deleteFdBatch.end()) {
+      logging::log2(logging::Debug, it->fd, " will be removed from pollfd vector");
+      it = _fds.erase(it);
+    }
+    else {
+      it++;
+    }
+  }
+  _deleteFdBatch.clear();
+}  
 
 // adds new connection to _clientMap -- move to pollhandling??
 

--- a/src/server/ServerRun.cpp
+++ b/src/server/ServerRun.cpp
@@ -66,16 +66,17 @@ void Server::process(void) {
 
   static int increment;
   increment++;
-  if (increment >= 8){
+  sleep(1);
+  if (increment >= 50){
     exit(0);
   }
   logging::log(logging::Warning, "Process");
   for (std::vector<pollfd>::iterator it = _fds.begin(); it != _fds.end();) {
     
   	int type = getSocketType(it->fd);
-    std::cout << getFdInfoString(*it, it->fd, type);
     handleCondition(*it, type); // sets conditions in client Connection, or accepts
                           // new connections
+    std::cout << getFdInfoString(*it, it->fd, type);
 	if (type != IS_LISTENER && shouldBeDeleted(it->fd, type) == true) {
       closeAndDelete(it->fd, type);
       it = _fds.erase(it);
@@ -161,7 +162,6 @@ short Server::determineEventsFwd(int ConditionsWanted){
 }
 
 void Server::closeAndDelete(int Fd, int type) {
-
   // TODO replace helper functions with type check
   close(Fd);
   if (socketIsClient(Fd))

--- a/src/server/ServerRun.cpp
+++ b/src/server/ServerRun.cpp
@@ -95,6 +95,7 @@ void Server::checkForNewCGI(int Fd) {
 		logging::log2(logging::Debug, "Got a new forward socket: ", fwdSock);
 		_fwdMap.insert(std::make_pair(fwdSock, connection));
     const pollfd newFd = {fwdSock, 0, 0};
+    exit(1);
     _newFdBatch.push_back(newFd);
 	}
 	return;
@@ -168,6 +169,11 @@ bool Server::shouldBeDeleted(int Fd, int Type) {
   }
   else if (Type == IS_FWD) {
   	int clientFd = _fwdMap.at(Fd)->getSock();
+    // There are 2 instances where a forward socket should be deleted:
+    // 1. if the forward socket itself is marked for deletion (CGI)
+    if (_clientMap.at(clientFd).getDeleteFwdStatus() == true)
+      return true;
+    // 2. if the forward socket's client is marked for deletion
   	return (_clientMap.at(clientFd).getDeleteStatus());
   }
   else {

--- a/src/server/ServerRun.cpp
+++ b/src/server/ServerRun.cpp
@@ -64,8 +64,16 @@ void Server::serveAll(void) {
 
 void Server::process(void) {
 
+  static int increment;
+  increment++;
+  if (increment >= 8){
+    exit(0);
+  }
+  logging::log(logging::Warning, "Process");
   for (std::vector<pollfd>::iterator it = _fds.begin(); it != _fds.end();) {
+    
   	int type = getSocketType(it->fd);
+    std::cout << getFdInfoString(*it, it->fd, type);
     handleCondition(*it, type); // sets conditions in client Connection, or accepts
                           // new connections
 	if (type != IS_LISTENER && shouldBeDeleted(it->fd, type) == true) {

--- a/src/server/ServerRun.cpp
+++ b/src/server/ServerRun.cpp
@@ -89,7 +89,7 @@ void Server::checkForNewCGI(int Fd) {
 	//logging::log(logging::Debug, "checking for new CGI");
 	Connection *connection  = &_clientMap.at(Fd);
 	//int potentialNewSocket = clientMap.at(Fd)->_socketForward;
-  if (_cgiFinished == true) {
+  if (connection->getCgiFinishedStatus() == true) {
     return;
   }
 	int fwdSock = connection->getSockForward();
@@ -97,7 +97,7 @@ void Server::checkForNewCGI(int Fd) {
 	if (fwdSock != -1 && _fwdMap.find(fwdSock) == _fwdMap.end()) {
 		logging::log2(logging::Debug, "Got a new forward socket: ", fwdSock);
 		_fwdMap.insert(std::make_pair(fwdSock, connection));
-    const pollfd newFd = {fwdSock, 0, 0};
+    const pollfd newFd = {fwdSock, determineEventsFwd(connection->getConditionsWanted()), 0};
     _newFdBatch.push_back(newFd);
 	}
 	return;
@@ -173,7 +173,7 @@ bool Server::shouldBeDeleted(int Fd, int Type) {
   	int clientFd = _fwdMap.at(Fd)->getSock();
     // There are 2 instances where a forward socket should be deleted:
     // 1. if the forward socket itself is marked for deletion (CGI)
-    if (_clientMap.at(clientFd).getDeleteFwdStatus() == true)
+    if (_clientMap.at(clientFd).getCgiFinishedStatus() == true)
       return true;
     // 2. if the forward socket's client is marked for deletion
   	return (_clientMap.at(clientFd).getDeleteStatus());

--- a/src/server/ServerRun.cpp
+++ b/src/server/ServerRun.cpp
@@ -89,6 +89,9 @@ void Server::checkForNewCGI(int Fd) {
 	//logging::log(logging::Debug, "checking for new CGI");
 	Connection *connection  = &_clientMap.at(Fd);
 	//int potentialNewSocket = clientMap.at(Fd)->_socketForward;
+  if (_cgiFinished == true) {
+    return;
+  }
 	int fwdSock = connection->getSockForward();
 	//logging::log2(logging::Debug, "fwdSock = : ", fwdSock);
 	if (fwdSock != -1 && _fwdMap.find(fwdSock) == _fwdMap.end()) {

--- a/src/server/ServerRun.cpp
+++ b/src/server/ServerRun.cpp
@@ -80,8 +80,8 @@ void Server::process(void) {
     it++;
   }
   serveAll();
-  updateEvents();
   _fds.insert(_fds.end(), _newFdBatch.begin(), _newFdBatch.end());
+  updateEvents();
   _newFdBatch.clear();
 }
 
@@ -94,6 +94,8 @@ void Server::checkForNewCGI(int Fd) {
 	if (fwdSock != -1 && _fwdMap.find(fwdSock) == _fwdMap.end()) {
 		logging::log2(logging::Debug, "Got a new forward socket: ", fwdSock);
 		_fwdMap.insert(std::make_pair(fwdSock, connection));
+    const pollfd newFd = {fwdSock, 0, 0};
+    _newFdBatch.push_back(newFd);
 	}
 	return;
 }

--- a/src/server/ServerRun.cpp
+++ b/src/server/ServerRun.cpp
@@ -155,6 +155,9 @@ short Server::determineEventsFwd(int ConditionsWanted){
 	return (events);
 }
 
+
+// currently not in use
+/*
 void Server::closeAndDelete(int Fd, int type) {
   // TODO replace helper functions with type check
   logging::log2(logging::Debug, "closing & deleting Fd: " , Fd);
@@ -164,13 +167,14 @@ void Server::closeAndDelete(int Fd, int type) {
   if (socketIsFwd(Fd))
     _fwdMap.erase(Fd);
 }
+*/
 
 /* shouldBeDeleted is called only by Server::process, which
 	guarantees that Type will be IS_CLINET or IS_FWD */
 
 bool Server::shouldBeDeleted(int Fd, int Type) {
   if (Type == IS_CLIENT){
-	return (_clientMap.at(Fd).getDeleteStatus());
+	  return (_clientMap.at(Fd).getDeleteStatus());
   }
   else if (Type == IS_FWD) {
   	int clientFd = _fwdMap.at(Fd)->getSock();

--- a/src/server/ServerRun.cpp
+++ b/src/server/ServerRun.cpp
@@ -98,7 +98,6 @@ void Server::checkForNewCGI(int Fd) {
 		logging::log2(logging::Debug, "Got a new forward socket: ", fwdSock);
 		_fwdMap.insert(std::make_pair(fwdSock, connection));
     const pollfd newFd = {fwdSock, 0, 0};
-    exit(1);
     _newFdBatch.push_back(newFd);
 	}
 	return;

--- a/src/server/ServerWrappers.cpp
+++ b/src/server/ServerWrappers.cpp
@@ -28,7 +28,7 @@
 struct addrinfo *Server::getAddrInfo(const Listen &Pair) {
 
   struct addrinfo *info;
-  logging::log2(logging::Debug, "getInfo() called with ip: ", Pair.ip);
+  //logging::log2(logging::Debug, "getInfo() called with ip: ", Pair.ip);
   const int ret =
       getaddrinfo(Pair.ip.c_str(), Pair.port.c_str(), &_hints, &info);
   if (ret != 0) {


### PR DESCRIPTION
Patches to restore CGI functionality. Sending a request for date.py now results in a response with the date and time!

- Lots of new debug print functions for Server
- Addition of _cgiFinished flag to Connection (in the end, may not need this afterall, but keeping for now)
- Foward sockets are now properly added to the pollfd vector
- Re-ordering of socket deletion within Server::process() to avoid bugs arising from separate client / fwd socket deletion
** This re-ordering makes me want to refactor my data structures altogether, but in the interest of time, I'm letting this be a patch as opposed to a restructure.

[!] - in CGIProcess:initForwardSocket,  I've added:

"_forwardSocket = sv[0];" after the other ForwardSocket assignment.

In debugging, I discovered that both are necessary for our current design. ForwardSocket is what's being polled, and _fowardSocket is what's being used in Reaction::receiveFromCGI() > _buffer.fileToBuf(_cgi.getForwardSocket(), Bytes).

You might have a better fix for this already in mind, but at least this inelegant patch is working!
