### PR TITLE
fix(CGI POST): create 2 scripts to test CGI POST Request and make the…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.d
 *.o
 *.out
-*.sh
+
 *.pdf
 *.vim
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tester
 cgi_tester
 webserv_tester
 webserv_tester/*
+post/*
 YoupiBanane
 webserv
 TODO.md

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,7 @@ clean:
 	$(RM) $(DEP)
 	$(RM) $(OBJ)
 	$(RM) $(OBJ_DIR)
+	$(RM) post
 
 fclean: clean clean_sa
 	$(RM) $(NAME)

--- a/inc/Reaction.hpp
+++ b/inc/Reaction.hpp
@@ -67,6 +67,7 @@ public:
 
   ProcessType	getProcessType(void) const;
   int			getForwardSocket(void) const;
+  bool			isInputDone(void) const;
   void			setTmpPathName(void);
   void			setFinalPathName(void);
 

--- a/scripts/date.sh
+++ b/scripts/date.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# This is run once a day - don't care about performance
+# RFC date must have GMT in the end
+# but GNU date return +0000 instead and bb date returns UTC
+# So we must strip +0000 or UTC and add GMT ourselves
+DATE=$(date -R -u | sed 's/\UTC/GMT/' | sed 's/\+0000/GMT/')
+echo "Date: $DATE\nStatus: 200\n";

--- a/scripts/post_body.sh
+++ b/scripts/post_body.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+POST_DIR="/home/julia/projects/webserv/post"
+
+mkdir -p "$POST_DIR"
+
+FILENAME="$POST_DIR/$(date +%s%N)_$$.txt"
+
+dd bs=1 count="$CONTENT_LENGTH" 2>/dev/null > "$FILENAME"
+
+echo "Content-Type: text/plain"
+echo ""
+echo "written to: $FILENAME"

--- a/scripts/post_query.sh
+++ b/scripts/post_query.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+POST_DIR="/home/julia/projects/webserv/post"
+
+mkdir -p "$POST_DIR"
+
+FILENAME="$POST_DIR/$(date +%s%N)_$$.txt"
+
+echo "$QUERY_STRING" > "$FILENAME"
+
+echo "Content-Type: text/plain"
+echo ""
+echo "written to: $FILENAME"
+

--- a/src/connection/Connection.cpp
+++ b/src/connection/Connection.cpp
@@ -94,7 +94,10 @@ void Connection::updateConditionsWanted(Reaction::ProcessType ProcessType){
 			_conditionsWanted = SockRead;
 			break;
 		case Reaction::CgiPost:
-			_conditionsWanted = SockWrite | SockRead | FSockWrite | FSockRead;
+			if (_react.isInputDone())
+				_conditionsWanted = SockWrite | FSockRead;
+			else
+				_conditionsWanted = SockWrite | SockRead | FSockWrite | FSockRead;
 			break;
 		case Reaction::CgiNotPost:
 			_conditionsWanted = SockWrite | FSockRead;

--- a/src/reaction/Reaction.cpp
+++ b/src/reaction/Reaction.cpp
@@ -42,6 +42,10 @@ int Reaction::getForwardSocket(void) const {
   return _cgi.getForwardSocket();
 }
 
+bool Reaction::isInputDone(void) const {
+  return _cgi.isInputDone();
+}
+
 void Reaction::setPathInfo(const PathInfo &PathInfo){
 	_pathInfo = PathInfo;
 }
@@ -196,8 +200,8 @@ bool Reaction::initPostBody(const Request &Req) {
     initSendError(CODE_403);
     return false;
   }
-  _receivedContLen = 0;
   _buffer = Req.getBuffer();
+  _receivedContLen = _buffer.getUsed();
   return true;
 }
 


### PR DESCRIPTION
- creates 2 bash scripts to test POST requests on CGIs. these scripts do create a file with a timestamp in the name and either write the query string into the file or the body of the Request
- split up the wanted Conditions for the CGI Post situation. cases: there is a body to read / there is nothing to read anymore (aka inputIsDone)
- if the Request is received in one big string, the buffer is handed over from request to reaction. Received Content Length within Reaction now correctly is bufUsed(). 