### PR TITLE
Httpversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 
 ## Description
-A fully functional HTTP/1.1 server built from scratch in C++98 as part of the 42 curriculum.
+A fully functional HTTP/1.0 server built from scratch in C++98 as part of the 42 curriculum.
 
 The server handles multiple concurrent client connections without threads, using `poll()` for non-blocking I/O multiplexing. It parses HTTP requests and generates responses, supports CGI script execution, file uploads, and the GET, POST, HEAD and DELETE methods. Server behavior is controlled through a nginx-inspired configuration file.
 

--- a/inc/Reaction.hpp
+++ b/inc/Reaction.hpp
@@ -113,6 +113,7 @@ private:
 
   HttpHeaders _headers;
   ProcessType _processType;
+  bool        _http09;
   size_t      _reqContLen;
   size_t      _receivedContLen;
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1 @@
+hello, this is index.html

--- a/src/reaction/CGIProcess.cpp
+++ b/src/reaction/CGIProcess.cpp
@@ -76,6 +76,9 @@ void CGIProcess::setInputDone(bool Done){
 
 void CGIProcess::setTimeLastActive(time_t Time) {
   _timeLastActive = Time;
+
+}
+ 
 void CGIProcess::setChildProcessDone(bool Done){
 	_childProcessDone = Done;
 }

--- a/src/reaction/Reaction.cpp
+++ b/src/reaction/Reaction.cpp
@@ -22,6 +22,7 @@ static void setMetadata(std::string &Metadata, const int Code,
 
 void Reaction::setDefaults(void) {
   _processType = NotInitialized;
+  _http09 = false;
   _metadataSent = false;
   _fdIn = -1;
   _body.clear();
@@ -29,7 +30,7 @@ void Reaction::setDefaults(void) {
 }
 
 Reaction::Reaction()
-    : _processType(NotInitialized), _metadataSent(false), _fdIn(-1) {
+    : _processType(NotInitialized), _http09(false), _metadataSent(false), _fdIn(-1) {
   _headers.unsetAll();
 }
 
@@ -65,16 +66,19 @@ void Reaction::init(const Request &Req, const int Socket, int &ForwardSocket) {
 	return ;
   }
   
-  // TODO: make more generic
-  /*
-  if (Req.getMajorV() != 1 || Req.getMinorV() != 0) {
+  _http09 = (Req.getMajorV() == 0 && Req.getMinorV() == 9);
+  if (_http09) {
+    if (Req.getMethod() != Get) {
+      initSendError(CODE_400);
+      return;
+    }
+  } else if (!((Req.getMinorV() == 0
+        && (Req.getMajorV() == 1 || Req.getMajorV() == 2 || Req.getMajorV() == 3))
+      || (Req.getMajorV() == 1 && Req.getMinorV() == 1))) {
+    // allow 1.0, 2.0, 3.0 and 1.1
     initSendFile(CODE_501, FILE_501);
     return;
   }
-  */ // commenting out because we need to allow 1.1 requests
-  // and can response with 1.0
-  //
-  //check if method is allowed in comparison to config
 
   //check if Resource is a CGI script
   if(_pathInfo.getCgiPath() == ""){
@@ -120,10 +124,11 @@ void Reaction::initSendError(const int Code) {
 void Reaction::initSendString(const int Code, const std::string &Body) {
   _headers.setContentLength(Body.size());
   _headers.setContentType(".html");
-  setMetadata(_metadata, Code, _headers);
+  if (!_http09)
+    setMetadata(_metadata, Code, _headers);
   _body = Body;
   _fdIn = -1;
-  _metadataSent = false;
+  _metadataSent = _http09;
   _processType = SendFile;
 }
 
@@ -144,8 +149,9 @@ void Reaction::initSendFile(const int Code, const char *File) {
     _headers.setContentType(strrchr(File, '.'));
   }
 
-  setMetadata(_metadata, Code, _headers);
-  _metadataSent = false;
+  if (!_http09)
+    setMetadata(_metadata, Code, _headers);
+  _metadataSent = _http09;
   _processType = SendFile;
 }
 

--- a/src/request/ParseRequestLine.cpp
+++ b/src/request/ParseRequestLine.cpp
@@ -74,6 +74,23 @@ void Request::parseRequestLine(const std::string &RequestLine)
 {
 	logging::log(logging::Debug, "parseStatusLine()");
 	std::vector<std::string> status = split(RequestLine, " ");
+	if (status.size() == 2) // HTTP/0.9 simple request: "METHOD /resource" — no version
+	{
+		try
+		{
+			parseMethod(status[0]);
+			parseResource(status[1]);
+			_majorVersion = 0;
+			_minorVersion = 9;
+			_state = COMPLETE;
+		}
+		catch (std::exception &e)
+		{
+			std::cerr << e.what() << '\n';
+			_state = INVALID;
+		}
+		return;
+	}
 	if (status.size() != 3)
 	{
         logging::log(logging::Debug, "Request is invalid after split of StatusLine");
@@ -108,7 +125,8 @@ bool Request::parseRequestLineFromBuffer()
     parseRequestLine(line);
     _buf.deleteFront(pos + 2);  // remove line + CRLF
     if (_state == INVALID)
-        return false; 
-    _state = HEADERS;
+        return false;
+    if (_state != COMPLETE)
+        _state = HEADERS;
     return true;
 }

--- a/test_configs/config.txt
+++ b/test_configs/config.txt
@@ -1,6 +1,6 @@
 server {
     listen 127.0.0.1:8080;
-    root /home/jhelbig/Desktop/webserv/;
+    root /home/julia/projects/webserv/;
     allow GET HEAD;
     autoindex on;
     max_request_body 1048576;


### PR DESCRIPTION
adds downwards compatibility for http0.9
-  if no http version is given, it is considered to be 0.9, no headers are expected then and response will be sent without headers