### PR TITLE
Fix for Uninitialized Jumps

### DIFF
--- a/src/connection/Connection.cpp
+++ b/src/connection/Connection.cpp
@@ -26,7 +26,7 @@
 
 Connection::Connection(const int Sock, const sockaddr_storage &Addr,
                        const socklen_t Addr_size, const Website &website)
-    : _conditionsWanted(SockRead), _sock(Sock), _sockForward(-1), _website(website), 
+    : _conditionsFulfilled(0), _conditionsWanted(SockRead), _sock(Sock), _sockForward(-1), _website(website), 
 	_delete(false), _cgiFinished(false), _addrSize(sizeof _addr)  {
 
   memset(&_info, 0, sizeof _info); // unneccessary? delete?

--- a/src/reaction/CGIProcess.cpp
+++ b/src/reaction/CGIProcess.cpp
@@ -76,6 +76,8 @@ void CGIProcess::setInputDone(bool Done){
 
 void CGIProcess::setTimeLastActive(time_t Time) {
   _timeLastActive = Time;
+}
+
 void CGIProcess::setChildProcessDone(bool Done){
 	_childProcessDone = Done;
 }

--- a/src/server/ServerWrappers.cpp
+++ b/src/server/ServerWrappers.cpp
@@ -155,6 +155,7 @@ void Server::setToListen(const int Sock) {
 int Server::acceptConnection(const int ListenerFd, ClientAddr *Candidate) {
 
   logging::log2(logging::Debug, "acceptConnection() on socket ", ListenerFd);
+  Candidate->addrSize = sizeof(struct sockaddr_storage);
   Candidate->clientSock = accept(
       ListenerFd, (struct sockaddr *)&Candidate->addr, &Candidate->addrSize);
   if (Candidate->clientSock == -1) {


### PR DESCRIPTION
Fix uninitialized variables, noticed while running Valgrind:

1) in Connection, conditionsFulfilled (now set to 0 in the constructor)
2) addrSize in wrapper for Accept (now set with sizeof before accept() is called)