### PR TITLE
fix(test with long header) : 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ webserv
 TODO.md
 www
 www/*
+hilaryTester/*

--- a/src/reaction/ReactionProcess.cpp
+++ b/src/reaction/ReactionProcess.cpp
@@ -56,7 +56,7 @@ bool Reaction::process(const int Socket, const size_t Bytes, const int Condition
   
   if (!checkOnChild())
     return false;
- //logging::log2(logging::Debug, "child finished for socket ", Socket);
+ logging::log2(logging::Debug, "child finished for socket ", Socket);
  // we just polled for what we need
   if (Condition & FSockRead)   
     receiveFromCGI(Bytes);

--- a/src/request/ParseHeaders.cpp
+++ b/src/request/ParseHeaders.cpp
@@ -13,7 +13,14 @@ bool Request::parseHeadersFromBuffer()
     const std::string s = _buf.getStringFromBuffer();
     const size_t pos = s.find("\r\n");
     if (pos == std::string::npos)
+    {
+        if (_buf.getFree() == 0) // header line will never fit in the buffer
+        {
+            logging::log(logging::Debug, "Header line too long");
+            _state = INVALID;
+        }
         return false;  	// header line not complete
+    }
     if (pos == 0)		// buffer was "\r\n\r\n"
     {
         _buf.deleteFront(2);  // remove second "\r\n"

--- a/src/request/ParseRequestLine.cpp
+++ b/src/request/ParseRequestLine.cpp
@@ -120,7 +120,14 @@ bool Request::parseRequestLineFromBuffer()
     const std::string s = _buf.getStringFromBuffer();
     const size_t pos = s.find("\r\n");
     if (pos == std::string::npos)
+    {
+        if (_buf.getFree() == 0) // line will never fit in the buffer
+        {
+            logging::log(logging::Debug, "Request line too long");
+            _state = INVALID;
+        }
         return false;  // line not complete yet - read more
+    }
     const std::string line = s.substr(0, pos);
     parseRequestLine(line);
     _buf.deleteFront(pos + 2);  // remove line + CRLF


### PR DESCRIPTION
checking length of Requestline and/or Header line - decline to handle this - setting a limit to the length of these line to the buffer-len - this does follow HTTP/1.0 behavior as far as I see - newer version then have 413 - request line to long - we now send 400 - bad Request